### PR TITLE
포스트 리스트에 커버 이미지가 보여지도록 수정

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -46,6 +46,13 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
             frontmatter {
               date(formatString: "YYYY. MM. DD. HH:mm")
               title
+              cover {
+                childImageSharp {
+                  resize(width: 300) {
+                    coverImage: src
+                  }
+                }
+              }
               tags
             }
           }

--- a/src/components/PostCard.js
+++ b/src/components/PostCard.js
@@ -5,9 +5,17 @@ import kebabCase from 'lodash/kebabCase';
 import { Item, Label, Header } from 'semantic-ui-react';
 
 const PostCard = ({ post }) => {
-  const { tags } = post.frontmatter;
+  const {
+    cover: {
+      childImageSharp: {
+        resize: { coverImage },
+      },
+    },
+    tags,
+  } = post.frontmatter;
   return (
     <Item style={{ paddingTop: '1.2em', paddingBottom: '1.2em' }}>
+      <Item.Image src={coverImage} />
       <Item.Content>
         <Item.Header>
           <Header as={Link} size="small" to={post.fields.slug}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -40,6 +40,13 @@ export const pageQuery = graphql`
           frontmatter {
             date(formatString: "YYYY. MM. DD. HH:mm")
             title
+            cover {
+              childImageSharp {
+                resize(width: 300) {
+                  coverImage: src
+                }
+              }
+            }
             tags
           }
         }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -13,6 +13,6 @@ collections:
     fields:
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Publish Date", name: "date", widget: "datetime"}
-      - {label: "Featured Image", name: "thumbnail", widget: "image"}
+      - {label: "Cover Image", name: "cover", widget: "image"}
       - {label: "Body", name: "body", widget: "markdown"}
       - {label: "Tags", name: "tags", widget: "list"}


### PR DESCRIPTION
- gatsby-node에서 커버 이미지 가져오도록 추가
- 최신 글 목록에서 커버 이미지 가져오도록 수정
- Netlify CMS에 커버 이미지 위젯 추가
- PostCard 컴포넌트에서 커버 이미지 출력